### PR TITLE
[32] Add RWD to BrandsBar

### DIFF
--- a/src/components/features/BrandsBar/BrandsBar.js
+++ b/src/components/features/BrandsBar/BrandsBar.js
@@ -9,8 +9,17 @@ const BrandsBar = () => {
   const [activePage, setActivePage] = useState(0);
 
   const brands = useSelector(state => state.brands);
+  const rwd = useSelector(state => state.rwdMode);
 
-  const brandsPerPage = 6;
+  const caluclateBrandsPerPage = rwdMode => {
+    if (rwdMode === 'wideScreen') return 6;
+    if (rwdMode === 'desktop') return 5;
+    if (rwdMode === 'tablet') return 4;
+    if (rwdMode === 'smallTablet') return 3;
+    if (rwdMode === 'mobile') return 2;
+  };
+
+  const brandsPerPage = caluclateBrandsPerPage(rwd);
   const pagesCount = Math.ceil(brands.length / brandsPerPage);
 
   const brandsToRender = brands.slice(
@@ -37,11 +46,13 @@ const BrandsBar = () => {
               <div className={styles.leftArrow} onClick={handleLeft}>
                 <FontAwesomeIcon icon={faChevronLeft} />
               </div>
-              {brandsToRender.map(brand => (
-                <div key={brand.id} className={styles.brand}>
-                  <img src={brand.image} alt={brand.name} draggable='false' />
-                </div>
-              ))}
+              <div className='row'>
+                {brandsToRender.map(brand => (
+                  <div key={brand.id} className={styles.brand}>
+                    <img src={brand.image} alt={brand.name} draggable='false' />
+                  </div>
+                ))}
+              </div>
               <div className={styles.rightArrow} onClick={handleRight}>
                 <FontAwesomeIcon icon={faChevronRight} />
               </div>

--- a/src/components/features/BrandsBar/BrandsBar.module.scss
+++ b/src/components/features/BrandsBar/BrandsBar.module.scss
@@ -7,7 +7,7 @@
   .panelBar {
     border-top: 1px solid $border-bar-color;
     border-bottom: 1px solid $border-bar-color;
-    padding: 0 15px;
+    padding: 0 10px;
   }
 
   .brand {
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 22px 8px;
+    margin: 22px 5px;
     height: 92px;
     width: 143px;
     border: 1px solid $border-bar-color;

--- a/src/components/features/BrandsBar/BrandsBar.module.scss
+++ b/src/components/features/BrandsBar/BrandsBar.module.scss
@@ -15,7 +15,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 22px 5px;
+    margin: 22px 8px;
     height: 92px;
     width: 143px;
     border: 1px solid $border-bar-color;

--- a/src/components/features/NewFurniture/NewFurniture.js
+++ b/src/components/features/NewFurniture/NewFurniture.js
@@ -46,8 +46,8 @@ class NewFurniture extends React.Component {
     const { rwdMode } = this.props;
     if (rwdMode === 'wideScreen') return 4;
     if (rwdMode === 'desktop') return 3;
-    if (rwdMode === 'tablet') return 2;
-    if (rwdMode === 'mobile') return 1;
+    if (rwdMode === 'tablet' || rwdMode === 'smallTablet') return 2;
+    if (rwdMode === 'mobile' || rwdMode === 'smallMobile') return 1;
   };
 
   calculatePagesCount = () => {

--- a/src/utils/getRwdMode.js
+++ b/src/utils/getRwdMode.js
@@ -1,10 +1,16 @@
 const getRwdModeByWidth = windowWidth => {
+  const smallMobile = 400;
   const mobile = 576;
+  const smallTablet = 768;
   const tablet = 992;
   const desktop = 1200;
 
-  if (windowWidth < mobile) {
+  if (windowWidth < smallMobile) {
+    return 'smallMobile';
+  } else if (windowWidth < mobile) {
     return 'mobile';
+  } else if (windowWidth < smallTablet) {
+    return 'smallTablet';
   } else if (windowWidth < tablet) {
     return 'tablet';
   } else if (windowWidth < desktop) {


### PR DESCRIPTION
Zadaniem jest stworzenie wersji mobilnych sekcji "Brands". Klient nie ma designów RWD, więc trzeba zrobić na własną rękę. 
W sliderze ma być tyle elementów, ile zmieści się w całości na danej szerokości ekranu.

Wykorzystałem RWDmode z reduxa, ze względu na mniejsze tablety i mniejsze telefony zmieniłem funkcję ustalającą tryb RWD jak i dostosowałem NewFurniture do tych poprawek.